### PR TITLE
fix identify on unlistable sources

### DIFF
--- a/src/source/query/identify.ts
+++ b/src/source/query/identify.ts
@@ -16,7 +16,7 @@ export function identify(pixel: Pixel, map: Map, limit: number = 10): Promise<IQ
         const source = (layer as Layer).getSource();
         if (source && 'query' in source) {
           const extended = (source as IExtended);
-          if (extended.isListable) {
+          if (extended.isListable()) {
             promises.push(extended.query(queryRequest));
           }
         }

--- a/src/source/query/identify.ts
+++ b/src/source/query/identify.ts
@@ -5,8 +5,8 @@ import Layer from 'ol/layer/Layer';
 import { IQueryResponse, constructQueryRequestFromPixel, IExtended } from '../IExtended';
 import { walk } from '../../utils';
 
-const defaultExtendedFilter = (extended: IExtended) => extended.isListable();
-export function identify(pixel: Pixel, map: Map, limit: number = 10, extendedFilter = defaultExtendedFilter): Promise<IQueryResponse[]> {
+export type IIdentifyExtendedFilter = (extended: IExtended) => boolean;
+export function identify(pixel: Pixel, map: Map, limit: number = 10, extendedFilter?: IIdentifyExtendedFilter): Promise<IQueryResponse[]> {
   if (map && pixel) {
     const promises: Array<Promise<IQueryResponse>> = [];
     const queryRequest = constructQueryRequestFromPixel(pixel, 2, map);
@@ -17,7 +17,7 @@ export function identify(pixel: Pixel, map: Map, limit: number = 10, extendedFil
         const source = (layer as Layer).getSource();
         if (source && 'query' in source) {
           const extended = (source as IExtended);
-          if (extendedFilter(extended)) {
+          if (!extendedFilter || extendedFilter(extended)) {
             promises.push(extended.query(queryRequest));
           }
         }

--- a/src/source/query/identify.ts
+++ b/src/source/query/identify.ts
@@ -5,8 +5,8 @@ import Layer from 'ol/layer/Layer';
 import { IQueryResponse, constructQueryRequestFromPixel, IExtended } from '../IExtended';
 import { walk } from '../../utils';
 
-export type IIdentifyExtendedFilter = (extended: IExtended) => boolean;
-export function identify(pixel: Pixel, map: Map, limit: number = 10, extendedFilter?: IIdentifyExtendedFilter): Promise<IQueryResponse[]> {
+export type IdentifyFilterType = (extended: IExtended) => boolean;
+export function identify(pixel: Pixel, map: Map, limit: number = 10, filter?: IdentifyFilterType): Promise<IQueryResponse[]> {
   if (map && pixel) {
     const promises: Array<Promise<IQueryResponse>> = [];
     const queryRequest = constructQueryRequestFromPixel(pixel, 2, map);
@@ -17,7 +17,7 @@ export function identify(pixel: Pixel, map: Map, limit: number = 10, extendedFil
         const source = (layer as Layer).getSource();
         if (source && 'query' in source) {
           const extended = (source as IExtended);
-          if (!extendedFilter || extendedFilter(extended)) {
+          if (!filter || filter(extended)) {
             promises.push(extended.query(queryRequest));
           }
         }

--- a/src/source/query/identify.ts
+++ b/src/source/query/identify.ts
@@ -5,7 +5,8 @@ import Layer from 'ol/layer/Layer';
 import { IQueryResponse, constructQueryRequestFromPixel, IExtended } from '../IExtended';
 import { walk } from '../../utils';
 
-export function identify(pixel: Pixel, map: Map, limit: number = 10): Promise<IQueryResponse[]> {
+const defaultExtendedFilter = (extended: IExtended) => extended.isListable;
+export function identify(pixel: Pixel, map: Map, limit: number = 10, extendedFilter = defaultExtendedFilter): Promise<IQueryResponse[]> {
   if (map && pixel) {
     const promises: Array<Promise<IQueryResponse>> = [];
     const queryRequest = constructQueryRequestFromPixel(pixel, 2, map);
@@ -16,7 +17,7 @@ export function identify(pixel: Pixel, map: Map, limit: number = 10): Promise<IQ
         const source = (layer as Layer).getSource();
         if (source && 'query' in source) {
           const extended = (source as IExtended);
-          if (extended.isListable()) {
+          if (extendedFilter(extended)) {
             promises.push(extended.query(queryRequest));
           }
         }

--- a/src/source/query/identify.ts
+++ b/src/source/query/identify.ts
@@ -15,7 +15,10 @@ export function identify(pixel: Pixel, map: Map, limit: number = 10): Promise<IQ
       if (layer.getVisible() && 'getSource' in layer) {
         const source = (layer as Layer).getSource();
         if (source && 'query' in source) {
-          promises.push((source as IExtended).query(queryRequest));
+          const extended = (source as IExtended);
+          if (extended.isListable) {
+            promises.push(extended.query(queryRequest));
+          }
         }
       }
       return true;

--- a/src/source/query/identify.ts
+++ b/src/source/query/identify.ts
@@ -5,7 +5,7 @@ import Layer from 'ol/layer/Layer';
 import { IQueryResponse, constructQueryRequestFromPixel, IExtended } from '../IExtended';
 import { walk } from '../../utils';
 
-const defaultExtendedFilter = (extended: IExtended) => extended.isListable;
+const defaultExtendedFilter = (extended: IExtended) => extended.isListable();
 export function identify(pixel: Pixel, map: Map, limit: number = 10, extendedFilter = defaultExtendedFilter): Promise<IQueryResponse[]> {
   if (map && pixel) {
     const promises: Array<Promise<IQueryResponse>> = [];


### PR DESCRIPTION
On ne lance pas d'identify sur une couche technique, au hasard une couche de mise en évidence