### PR TITLE
[Fix] Gestion des erreurs de traitement des loaders

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+ARG CONTAINER_USER=node
+ARG NODE_VERSION=0-18
+ARG VARIANT=bullseye
+FROM mcr.microsoft.com/devcontainers/typescript-node:${NODE_VERSION}-${VARIANT}
+
+# Montage du cache des extensions vscode
+RUN mkdir -p /home/node/.vscode-server/extensions \
+    && mkdir -p /home/node/.vscode-server/bin \
+    && mkdir -p /home/node/.vscode-server/data \
+    && chown -R node /home/node/.vscode-server
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG NVM_NODE_VERSION=v18
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NVM_NODE_VERSION}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,59 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+  "name": "aol",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "CONTAINER_USER": "node",
+      "NODE_VERSION": "0-18",
+      "VARIANT": "bullseye"
+    }
+  },
+
+  // An array of additional mount points to add to the container when created.
+  // Each value is a string that accepts the same values as the Docker CLI --mount flag.
+  // Environment and pre-defined variables may be referenced in the value
+  "mounts": [
+    // enable cache for vscode extension
+    "source=${localWorkspaceFolderBasename}-vscode-extension,target=/home/node/.vscode-server/extensions,type=volume",
+    // enable cache for node
+    "source=cache-node-18,target=/home/node/.npm,type=volume",
+    // enable cache for node_modules
+    "source=${localWorkspaceFolderBasename}-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume",
+    // bind $HOME/.npmrc
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.npmrc,target=/home/node/.npmrc,type=bind,consistency=cached"
+  ],
+
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {
+      "ppa": true,
+      "version": "latest"
+    },
+    "ghcr.io/jungaretti/features/make:1": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  },
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // A command string or list of command arguments to run on the host machine
+  // before the container is created.
+  "initializeCommand": "/bin/bash .devcontainer/initializeCommand.sh",
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "/bin/bash .devcontainer/postCreateCommand.sh",
+
+  // Configure tool-specific properties.
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "donjayamanne.githistory"
+      ]
+    }
+  },
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  "remoteUser": "node"
+}

--- a/.devcontainer/initializeCommand.sh
+++ b/.devcontainer/initializeCommand.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+[ -e "$HOME/.npmrc" ] || { echo "Le fichier $HOME/.npmrc n'est pas présent dans WSL. Sortie avec code 1."; exit 1; }

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,17 @@
+# Grant node_modules to user node
+sudo chown node node_modules
+
+# Download and install Coexya certificates
+SCRIPTS_URL='https://lyovgitlabsig.coexya.lan/devops/terraform/utils/-/raw/master'
+INSTALL_CERT_SCRIPT_NAME='03_install_ca_root.sh'
+INSTALL_CERT_SCRIPT_FILE=./$INSTALL_CERT_SCRIPT_NAME
+## DL script
+echo "Download script : $INSTALL_CERT_SCRIPT_NAME"
+curl --insecure "$SCRIPTS_URL/$INSTALL_CERT_SCRIPT_NAME" -o $INSTALL_CERT_SCRIPT_FILE
+## Run script
+echo "Run script : $INSTALL_CERT_SCRIPT_NAME"
+sudo bash $INSTALL_CERT_SCRIPT_FILE
+## Remove script
+rm $INSTALL_CERT_SCRIPT_FILE
+## Register certificate to npm
+npm config set cafile /etc/ssl/certs/LYOVDEV2PKI01.pem

--- a/src/load/kml.ts
+++ b/src/load/kml.ts
@@ -11,17 +11,21 @@ const kmlFormat = new KML({ extractStyles: true, showPointNames: false });
  * Load KML from file.
  */
 export function loadKML(file: File, map: Map): Promise<LocalVector> {
-  return new Promise<LocalVector>((resolve) => {
+  return new Promise<LocalVector>((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = () => {
-      const kmlString = reader.result as string;
-      const name = `${kmlFormat.readName(kmlString)} (${file.name})`;
-      const features: Feature[] = kmlFormat.readFeatures(kmlString, {
-        featureProjection: map.getView().getProjection(),
-      }) as Feature[];
-      const localVectorSource = SourceFactory.create(SourceTypeEnum.LocalVector, { name }) as LocalVector;
-      localVectorSource.addFeatures(features);
-      resolve(localVectorSource);
+      try {
+        const kmlString = reader.result as string;
+        const name = `${kmlFormat.readName(kmlString)} (${file.name})`;
+        const features: Feature[] = kmlFormat.readFeatures(kmlString, {
+          featureProjection: map.getView().getProjection(),
+        }) as Feature[];
+        const localVectorSource = SourceFactory.create(SourceTypeEnum.LocalVector, { name }) as LocalVector;
+        localVectorSource.addFeatures(features);
+        resolve(localVectorSource);
+      } catch (err) {
+        reject(err);
+      }
     };
     reader.readAsText(file);
   });

--- a/src/load/kmz.ts
+++ b/src/load/kmz.ts
@@ -14,56 +14,65 @@ const kmlFormat = new KML({ extractStyles: true, showPointNames: false });
 export function loadKMZ(file: File, map: Map): Promise<LocalVector> {
   return new Promise<LocalVector>((resolve, reject) => {
     const zipFile = new JSZip();
-    zipFile.loadAsync(file).then((zip) => {
-      const promises = Object.keys(zip.files)
-        .map((name) => zip.files[name])
-        .map(
-          (entry) =>
-            new Promise<{ name: string; data: string }>((resolve2) => {
-              entry.async('blob').then((blob) => {
-                if (/\.(jpe?g|png|gif|bmp)$/i.test(entry.name)) {
-                  const reader = new FileReader();
-                  reader.onload = () => {
-                    resolve2({
-                      name: entry.name,
-                      data: reader.result as any,
-                    });
-                  };
-                  reader.readAsDataURL(blob);
-                } else {
-                  const reader = new FileReader();
-                  reader.onload = () => {
-                    resolve2({
-                      name: entry.name,
-                      data: reader.result as any,
-                    });
-                  };
-                  reader.readAsText(blob);
-                }
+    zipFile.loadAsync(file).then(
+      (zip) => {
+        const promises = Object.keys(zip.files)
+          .map((name) => zip.files[name])
+          .map(
+            (entry) =>
+              new Promise<{ name: string; data: string }>((resolve2) => {
+                entry.async('blob').then((blob) => {
+                  if (/\.(jpe?g|png|gif|bmp)$/i.test(entry.name)) {
+                    const reader = new FileReader();
+                    reader.onload = () => {
+                      resolve2({
+                        name: entry.name,
+                        data: reader.result as any,
+                      });
+                    };
+                    reader.readAsDataURL(blob);
+                  } else {
+                    const reader = new FileReader();
+                    reader.onload = () => {
+                      resolve2({
+                        name: entry.name,
+                        data: reader.result as any,
+                      });
+                    };
+                    reader.readAsText(blob);
+                  }
+                });
+              }),
+          );
+        Promise.all(promises).then(
+          (elements) => {
+            try {
+              const imageElements = elements.filter((element) => /\.(jpe?g|png|gif|bmp)$/i.test(element.name));
+              const docElement = elements.filter((element) => element.name === 'doc.kml').pop();
+              let kmlString = docElement.data;
+              imageElements.forEach((imageElement) => {
+                const imageName = imageElement.name.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, '\\$1');
+                kmlString = kmlString.replace(new RegExp(imageName, 'g'), imageElement.data);
               });
-            }),
+              const name = `${kmlFormat.readName(kmlString)} (${file.name})`;
+              const features: Feature[] = kmlFormat.readFeatures(kmlString, {
+                featureProjection: map.getView().getProjection(),
+              }) as Feature[];
+              const localVectorSource = SourceFactory.create(SourceTypeEnum.LocalVector, { name }) as LocalVector;
+              localVectorSource.addFeatures(features);
+              resolve(localVectorSource);
+            } catch (err) {
+              reject(err);
+            }
+          },
+          (err) => {
+            reject(err);
+          },
         );
-      Promise.all(promises).then(
-        (elements) => {
-          const imageElements = elements.filter((element) => /\.(jpe?g|png|gif|bmp)$/i.test(element.name));
-          const docElement = elements.filter((element) => element.name === 'doc.kml').pop();
-          let kmlString = docElement.data;
-          imageElements.forEach((imageElement) => {
-            const imageName = imageElement.name.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, '\\$1');
-            kmlString = kmlString.replace(new RegExp(imageName, 'g'), imageElement.data);
-          });
-          const name = `${kmlFormat.readName(kmlString)} (${file.name})`;
-          const features: Feature[] = kmlFormat.readFeatures(kmlString, {
-            featureProjection: map.getView().getProjection(),
-          }) as Feature[];
-          const localVectorSource = SourceFactory.create(SourceTypeEnum.LocalVector, { name }) as LocalVector;
-          localVectorSource.addFeatures(features);
-          resolve(localVectorSource);
-        },
-        (err) => {
-          reject(err);
-        },
-      );
-    });
+      },
+      (err) => {
+        reject(err);
+      },
+    );
   });
 }


### PR DESCRIPTION
Ajout d'une meilleure gestion des erreurs de traitement des loaders. Le fait de catch les erreurs et de les rejeter via la promesse globale du loader, permet de traiter les erreurs à plus haut niveau (appel du loader).

Cas rencontré qui a mené ce correctif : chargement d'un shp zippé qui ne possède pas de fichier dbf => le traitement de lecture du shp plante sans que l'erreur puisse être traitée au dessus. 